### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,6 +5,7 @@
 		"type": "git",
 		"url": "git://github.com/trentrichardson/jQuery-Timepicker-Addon.git"
 	},
+	"main": ["dist/jquery-ui-timepicker-addon.js", "dist/jquery-ui-timepicker-addon.css"],
 	"dependencies": {
 	}
 }


### PR DESCRIPTION
When rails-assets tries to convert the bower package, it runs into a problem:
```
Post-install message from rails-assets-jqueryui-timepicker-addon:
This component doesn't define main assets in bower.json.
```
This just adds the main assets to the bower.json.